### PR TITLE
試合を行い結果をデータベースに登録する処理の実装(lec04)

### DIFF
--- a/src/main/java/oit/is/z2395/kaizi/janken/controller/JankenController.java
+++ b/src/main/java/oit/is/z2395/kaizi/janken/controller/JankenController.java
@@ -76,6 +76,51 @@ public class JankenController {
     User opponentUser = userMapper.selectById(id);
     model.addAttribute("userName", prin.getName());
     model.addAttribute("opponentName", opponentUser.getName());
+    model.addAttribute("opponentId", id);
+
+    return "match.html";
+  }
+
+  @GetMapping("/fight/{userHand}")
+  public String fight(@PathVariable String userHand, @RequestParam int id, Principal prin, ModelMap model) {
+    User opponentUser = userMapper.selectById(id);
+    model.addAttribute("userName", prin.getName());
+    model.addAttribute("opponentName", opponentUser.getName());
+    model.addAttribute("opponentId", id);
+
+    String result;
+    String cpuHand;
+
+    cpuHand = Janken.hand_short_to_str(Janken.cpu_choice_hand(Janken.hand_str_to_short(userHand)));
+
+    switch (Janken.judge(Janken.hand_str_to_short(userHand), Janken.hand_str_to_short(cpuHand))) {
+      case 1:
+        result = "You Win!";
+        break;
+
+      case 0:
+        result = "Draw.";
+        break;
+
+      case -1:
+        result = "You Lose.";
+        break;
+
+      default:
+        result = "Occurred Undefined Error.";
+        break;
+    }
+
+    model.addAttribute("userHand", userHand);
+    model.addAttribute("opponentHand", cpuHand);
+    model.addAttribute("jankenResult", result);
+
+    Match match = new Match();
+    match.setUser1(userMapper.selectByName(prin.getName()).getId());
+    match.setUser2(id);
+    match.setUser1Hand(userHand);
+    match.setUser2Hand(cpuHand);
+    matchMapper.insertMatch(match);
 
     return "match.html";
   }

--- a/src/main/java/oit/is/z2395/kaizi/janken/model/MatchMapper.java
+++ b/src/main/java/oit/is/z2395/kaizi/janken/model/MatchMapper.java
@@ -10,6 +10,10 @@ import org.apache.ibatis.annotations.Select;
 @Mapper
 public interface MatchMapper {
 
-  @Select("SELECT * FROM matches")
+  @Select("SELECT * FROM matches;")
   ArrayList<Match> selectAllMatch();
+
+  @Insert("INSERT INTO matches (user1, user2, user1Hand, user2Hand) VALUES (#{user1}, #{user2}, #{user1Hand}, #{user2Hand});")
+  @Options(useGeneratedKeys = true, keyColumn = "id", keyProperty = "id")
+  void insertMatch(Match match);
 }

--- a/src/main/java/oit/is/z2395/kaizi/janken/model/UserMapper.java
+++ b/src/main/java/oit/is/z2395/kaizi/janken/model/UserMapper.java
@@ -10,9 +10,12 @@ import org.apache.ibatis.annotations.Select;
 @Mapper
 public interface UserMapper {
 
-  @Select("SELECT * FROM users")
+  @Select("SELECT * FROM users;")
   ArrayList<User> selectAllUser();
 
-  @Select("SELECT * FROM users WHERE id = #{id}")
+  @Select("SELECT * FROM users WHERE id = #{id};")
   User selectById(int id);
+
+  @Select("SELECT * FROM users WHERE name = #{name};")
+  User selectByName(String name);
 }

--- a/src/main/resources/templates/match.html
+++ b/src/main/resources/templates/match.html
@@ -20,11 +20,14 @@
 
   <p>[[${userName}]] vs [[${opponentName}]]</p>
 
-  <a href="/play_janken/Gu">ぐー</a> <a href="/play_janken/Choki">ちょき</a> <a href="/play_janken/Pa">ぱー</a>
+  <a th:href="@{/fight/Gu(id=${opponentId})}">ぐー</a> <a th:href="@{/fight/Choki(id=${opponentId})}">ちょき</a> <a
+    th:href="@{/fight/Pa(id=${opponentId})}">ぱー</a>
 
   <div th:if="${userHand}">あなたの手 [[${userHand}]]</div>
   <div th:if="${opponentHand}">相手の手 [[${opponentHand}]]</div>
   <div th:if="${jankenResult}">結果 [[${jankenResult}]]</div>
+
+  <p><a href="/janken">もどる</a></p>
 </body>
 
 </html>


### PR DESCRIPTION
[概要]
　第4回応用演習(授業課題) Web資料の個人演習「試合を行い結果をデータベースに登録する処理の実装」の項を実装し完了した。

[動作確認]
　確認済み。

[DoD]
　“ほんだ”，でログインし，http://localhost:8080/janken でCPUのリンクをクリックすると，match.htmlに遷移し，「ほんだ vs CPU」の下にじゃんけんの手のリンクが表示されている
　じゃんけんの手のリンクをクリックするとmatch.html(@GetMapper(“/fight”)として定義したメソッドを利用して表示)に「ほんだの手」と「CPUの手」及びじゃんけんの結果が表示される．同時にmatchesテーブルにほんだとCPUのidと手が挿入される

[実行/実装事項]
・(省略)