### PR TITLE
定義名のリファクタリング1

### DIFF
--- a/src/main/java/oit/is/z2395/kaizi/janken/controller/JankenController.java
+++ b/src/main/java/oit/is/z2395/kaizi/janken/controller/JankenController.java
@@ -23,7 +23,7 @@ public class JankenController {
   private MatchMapper matchMapper;
 
   @GetMapping("/janken")
-  public String join_game(Principal prin, ModelMap model) {
+  public String joinGame(Principal prin, ModelMap model) {
     String loginUser = prin.getName();
     model.addAttribute("userName", loginUser);
 
@@ -40,13 +40,13 @@ public class JankenController {
   }
 
   @GetMapping("/play_janken/{userHand}")
-  public String play_game(@PathVariable String userHand, ModelMap model) {
+  public String playGame(@PathVariable String userHand, ModelMap model) {
     String result;
     String cpuHand;
 
-    cpuHand = Janken.hand_short_to_str(Janken.cpu_choice_hand(Janken.hand_str_to_short(userHand)));
+    cpuHand = Janken.handShort2Str(Janken.cpuChoiceHand(Janken.handStr2Short(userHand)));
 
-    switch (Janken.judge(Janken.hand_str_to_short(userHand), Janken.hand_str_to_short(cpuHand))) {
+    switch (Janken.judge(Janken.handStr2Short(userHand), Janken.handStr2Short(cpuHand))) {
       case 1:
         result = "You Win!";
         break;
@@ -91,9 +91,9 @@ public class JankenController {
     String result;
     String cpuHand;
 
-    cpuHand = Janken.hand_short_to_str(Janken.cpu_choice_hand(Janken.hand_str_to_short(userHand)));
+    cpuHand = Janken.handShort2Str(Janken.cpuChoiceHand(Janken.handStr2Short(userHand)));
 
-    switch (Janken.judge(Janken.hand_str_to_short(userHand), Janken.hand_str_to_short(cpuHand))) {
+    switch (Janken.judge(Janken.handStr2Short(userHand), Janken.handStr2Short(cpuHand))) {
       case 1:
         result = "You Win!";
         break;

--- a/src/main/java/oit/is/z2395/kaizi/janken/model/Janken.java
+++ b/src/main/java/oit/is/z2395/kaizi/janken/model/Janken.java
@@ -9,7 +9,7 @@ public class Janken {
    * @param hand String, String型で表されたじゃんけんの手
    * @return short, 変換表(switch-case文)に沿って変換されたshort型のじゃんけんの手を返す.
    */
-  public static short hand_str_to_short(String hand) {
+  public static short handStr2Short(String hand) {
     short res;
     switch (hand) {
       case "Gu":
@@ -38,7 +38,7 @@ public class Janken {
    * @param hand short, short型で表されたじゃんけんの手
    * @return String, 変換表(switch-case文)に沿って変換されたString型のじゃんけんの手を返す.
    */
-  public static String hand_short_to_str(short hand) {
+  public static String handShort2Str(short hand) {
     String res;
     switch (hand) {
       case 0:
@@ -86,11 +86,11 @@ public class Janken {
    * @param myHand short, プレイヤーのじゃんけんの手
    * @return short, CPUが出すじゃんけんの手
    */
-  public static short cpu_choice_hand(short myHand) {
-    return cpu_choice_hand(myHand, 10, 20, 70);
+  public static short cpuChoiceHand(short myHand) {
+    return cpuChoiceHand(myHand, 10, 20, 70);
   }
 
-  public static short cpu_choice_hand(short myHand, int winRate, int drawRate, int loseRate) {
+  public static short cpuChoiceHand(short myHand, int winRate, int drawRate, int loseRate) {
     Random rnd = new Random();
     int samp = rnd.nextInt(winRate + drawRate + loseRate);
     short playRes = 0;


### PR DESCRIPTION
※授業資料記載外のプルリクエスト
[概要]
　第4回応用演習(授業課題) Web資料の個人演習終了時点で作成されていたソースコードの、名前の定義についてリファクタリングを行った。
　具体的にはsnake_caseを除去し、それをcamelCaseに置き換えた。

[動作確認]
　リファクタリング前後で同様の動作をすれば良い。確認済み。

[DoD]
　リファクタリング前後で同様(第4回個人課題終了後と同じ)の動作をすれば良い。

[実行/実装事項]
・(省略)