### PR TITLE
ログイン後にアクティブな試合を表示する(lec05)

### DIFF
--- a/src/main/java/oit/is/z2395/kaizi/janken/controller/JankenController.java
+++ b/src/main/java/oit/is/z2395/kaizi/janken/controller/JankenController.java
@@ -38,6 +38,9 @@ public class JankenController {
     ArrayList<Match> matches = matchMapper.selectAllMatch();
     model.addAttribute("matches", matches);
 
+    ArrayList<MatchInfo> matchinfos = matchInfoMapper.selectActiveMatch();
+    model.addAttribute("matchinfos", matchinfos);
+
     return "janken.html";
   }
 

--- a/src/main/java/oit/is/z2395/kaizi/janken/model/MatchInfoMapper.java
+++ b/src/main/java/oit/is/z2395/kaizi/janken/model/MatchInfoMapper.java
@@ -14,4 +14,7 @@ public interface MatchInfoMapper {
   @Options(useGeneratedKeys = true, keyColumn = "id", keyProperty = "id")
   void startMatch(MatchInfo matchinfo);
 
+  @Select("SELECT * FROM matchinfo WHERE isActive = TRUE")
+  ArrayList<MatchInfo> selectActiveMatch();
+
 }

--- a/src/main/resources/templates/janken.html
+++ b/src/main/resources/templates/janken.html
@@ -24,6 +24,16 @@
   <div th:if="${opponentHand}">相手の手 [[${opponentHand}]]</div>
   <div th:if="${jankenResult}">結果 [[${jankenResult}]]</div>
 
+  <ul>
+    <b>アクティブな試合: </b>
+    <li th:each="active : ${matchinfos}">
+      id: [[${active.id}]],
+      user1: [[${active.user1}]],
+      user2: [[${active.user2}]],
+      isActive: [[${active.isActive}]]
+    </li>
+  </ul>
+
   <div th:if="${entry}">
     <ul>
       <b>エントリーユーザ: </b>


### PR DESCRIPTION
[概要]
　第5回応用演習(授業課題) Web資料の個人演習「ログイン後にアクティブな試合を表示する」の項を実装し完了した。

[動作確認]
　確認済み。

[DoD]
　「いがき」でログインし，jankenのページのエントリーから「ほんだ」を選び，matchのページで手を選び，waitのページに遷移する
>> 正常にページが遷移した．

　シークレットモードで「ほんだ」でログインし，jankenのページでアクティブな試合について「id:(MatchInfoのidが表示される) user1:(MatchInfoのuser1が表示される) user2:(MatchInfoのuser1が表示される) isActive:(MatchInfoのisActiveが表示される)」の様に表示される
>> 正しく表示された．

[実行/実装事項]
・(省略)