### PR TITLE
対戦相手が手を選び非同期処理で結果を表示する(lec05)

### DIFF
--- a/src/main/java/oit/is/z2395/kaizi/janken/JankenApplication.java
+++ b/src/main/java/oit/is/z2395/kaizi/janken/JankenApplication.java
@@ -2,12 +2,16 @@ package oit.is.z2395.kaizi.janken;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
+@EnableAsync
+@EnableScheduling
 @SpringBootApplication
 public class JankenApplication {
 
-	public static void main(String[] args) {
-		SpringApplication.run(JankenApplication.class, args);
-	}
+  public static void main(String[] args) {
+    SpringApplication.run(JankenApplication.class, args);
+  }
 
 }

--- a/src/main/java/oit/is/z2395/kaizi/janken/controller/JankenController.java
+++ b/src/main/java/oit/is/z2395/kaizi/janken/controller/JankenController.java
@@ -1,5 +1,6 @@
 package oit.is.z2395.kaizi.janken.controller;
 
+import java.io.IOException;
 import java.security.Principal;
 import java.util.ArrayList;
 
@@ -10,19 +11,26 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 import oit.is.z2395.kaizi.janken.model.*;
+
+import oit.is.z2395.kaizi.janken.service.AsyncKekka;
 
 @Controller
 public class JankenController {
   @Autowired
   private Entry entry = new Entry();
+
   @Autowired
   private UserMapper userMapper;
   @Autowired
   private MatchMapper matchMapper;
   @Autowired
   private MatchInfoMapper matchInfoMapper;
+
+  @Autowired
+  private AsyncKekka resultDisplayer;
 
   @GetMapping("/janken")
   public String joinGame(Principal prin, ModelMap model) {
@@ -38,7 +46,7 @@ public class JankenController {
     ArrayList<Match> matches = matchMapper.selectAllMatch();
     model.addAttribute("matches", matches);
 
-    ArrayList<MatchInfo> matchinfos = matchInfoMapper.selectActiveMatch();
+    ArrayList<MatchInfo> matchinfos = matchInfoMapper.selectAllActiveMatch();
     model.addAttribute("matchinfos", matchinfos);
 
     return "janken.html";
@@ -51,23 +59,7 @@ public class JankenController {
 
     cpuHand = Janken.handShort2Str(Janken.cpuChoiceHand(Janken.handStr2Short(userHand)));
 
-    switch (Janken.judge(Janken.handStr2Short(userHand), Janken.handStr2Short(cpuHand))) {
-      case 1:
-        result = "You Win!";
-        break;
-
-      case 0:
-        result = "Draw.";
-        break;
-
-      case -1:
-        result = "You Lose.";
-        break;
-
-      default:
-        result = "Occurred Undefined Error.";
-        break;
-    }
+    result = Janken.outputResult(userHand, cpuHand);
 
     model.addAttribute("userHand", userHand);
     model.addAttribute("opponentHand", cpuHand);
@@ -88,18 +80,50 @@ public class JankenController {
 
   @GetMapping("/fight/{userHand}")
   public String fight(@PathVariable String userHand, @RequestParam int id, Principal prin, ModelMap model) {
-    User opponentUser = userMapper.selectById(id);
+    int userId = userMapper.selectByName(prin.getName()).getId();
+    int opponentId = id;
+    User opponentUser = userMapper.selectById(opponentId);
     model.addAttribute("userName", prin.getName());
     model.addAttribute("opponentName", opponentUser.getName());
-    model.addAttribute("opponentId", id);
+    model.addAttribute("opponentId", opponentId);
 
-    MatchInfo matchinfo = new MatchInfo();
-    matchinfo.setUser1(userMapper.selectByName(prin.getName()).getId());
-    matchinfo.setUser2(id);
-    matchinfo.setUser1Hand(userHand);
-    matchinfo.setIsActive(true);
-    matchInfoMapper.startMatch(matchinfo);
+    MatchInfo activeMatch = matchInfoMapper.selectActiveMatchByUsers(opponentId, userId);
+    if (activeMatch != null) {
+      // アクティブな試合への対戦(受動的)
+      Match match = new Match();
+      match.setUser1(opponentId);
+      match.setUser2(userId);
+      match.setUser1Hand(activeMatch.getUser1Hand());
+      match.setUser2Hand(userHand);
+      match.setIsActive(true);
+      matchMapper.insertMatch(match);
+
+      matchInfoMapper.deactivateMatchById(activeMatch.getId());
+
+    } else {
+      // 新規対戦(能動的)
+      MatchInfo matchinfo = new MatchInfo();
+      matchinfo.setUser1(userId);
+      matchinfo.setUser2(opponentId);
+      matchinfo.setUser1Hand(userHand);
+      matchinfo.setIsActive(true);
+      matchInfoMapper.startMatch(matchinfo);
+    }
 
     return "wait.html";
+  }
+
+  @GetMapping("/fight/waiting")
+  public SseEmitter fightWaiting(Principal prin) {
+    SseEmitter emitter = new SseEmitter(Long.MAX_VALUE);
+    int userId = userMapper.selectByName(prin.getName()).getId();
+
+    try {
+      this.resultDisplayer.waitResult(emitter, userId);
+    } catch (IOException e) {
+
+    }
+
+    return emitter;
   }
 }

--- a/src/main/java/oit/is/z2395/kaizi/janken/model/Janken.java
+++ b/src/main/java/oit/is/z2395/kaizi/janken/model/Janken.java
@@ -126,4 +126,28 @@ public class Janken {
 
     return cpuHand;
   }
+
+  public static String outputResult(String yourHand, String opponentHand) {
+    String result;
+
+    switch (Janken.judge(Janken.handStr2Short(yourHand), Janken.handStr2Short(opponentHand))) {
+      case 1:
+        result = "You Win!";
+        break;
+
+      case 0:
+        result = "Draw.";
+        break;
+
+      case -1:
+        result = "You Lose.";
+        break;
+
+      default:
+        result = "Occurred Undefined Error.";
+        break;
+    }
+
+    return result;
+  }
 }

--- a/src/main/java/oit/is/z2395/kaizi/janken/model/MatchInfoMapper.java
+++ b/src/main/java/oit/is/z2395/kaizi/janken/model/MatchInfoMapper.java
@@ -6,15 +6,21 @@ import org.apache.ibatis.annotations.Insert;
 import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Options;
 import org.apache.ibatis.annotations.Select;
+import org.apache.ibatis.annotations.Update;
 
 @Mapper
 public interface MatchInfoMapper {
 
-  @Insert("INSERT INTO matchinfo (user1, user2, user1Hand, isActive) VALUES(#{user1}, #{user2}, #{user1Hand}, TRUE)")
+  @Insert("INSERT INTO matchinfo (user1, user2, user1Hand, isActive) VALUES(#{user1}, #{user2}, #{user1Hand}, TRUE);")
   @Options(useGeneratedKeys = true, keyColumn = "id", keyProperty = "id")
   void startMatch(MatchInfo matchinfo);
 
-  @Select("SELECT * FROM matchinfo WHERE isActive = TRUE")
-  ArrayList<MatchInfo> selectActiveMatch();
+  @Select("SELECT * FROM matchinfo WHERE isActive = TRUE;")
+  ArrayList<MatchInfo> selectAllActiveMatch();
 
+  @Select("SELECT * FROM matchinfo WHERE isActive = TRUE AND user1 = #{user1} AND user2 = #{user2};")
+  MatchInfo selectActiveMatchByUsers(int user1, int user2);
+
+  @Update("UPDATE matchinfo SET isActive = FALSE WHERE id = #{id};")
+  void deactivateMatchById(int id);
 }

--- a/src/main/java/oit/is/z2395/kaizi/janken/model/MatchMapper.java
+++ b/src/main/java/oit/is/z2395/kaizi/janken/model/MatchMapper.java
@@ -6,6 +6,7 @@ import org.apache.ibatis.annotations.Insert;
 import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Options;
 import org.apache.ibatis.annotations.Select;
+import org.apache.ibatis.annotations.Update;
 
 @Mapper
 public interface MatchMapper {
@@ -16,4 +17,10 @@ public interface MatchMapper {
   @Insert("INSERT INTO matches (user1, user2, user1Hand, user2Hand, isActive) VALUES (#{user1}, #{user2}, #{user1Hand}, #{user2Hand}, #{isActive});")
   @Options(useGeneratedKeys = true, keyColumn = "id", keyProperty = "id")
   void insertMatch(Match match);
+
+  @Update("UPDATE matches SET isActive = FALSE WHERE id = #{id};")
+  void deactivateMatchById(int id);
+
+  @Select("SELECT * FROM matches WHERE isActive = TRUE AND (user1 = #{user_id} OR user2 = #{user_id});")
+  Match selectActiveMatchByUser(int user_id);
 }

--- a/src/main/java/oit/is/z2395/kaizi/janken/service/AsyncKekka.java
+++ b/src/main/java/oit/is/z2395/kaizi/janken/service/AsyncKekka.java
@@ -1,0 +1,66 @@
+package oit.is.z2395.kaizi.janken.service;
+
+import java.io.IOException;
+import java.util.concurrent.TimeUnit;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+import oit.is.z2395.kaizi.janken.model.*;
+
+@Service
+public class AsyncKekka {
+  private final Logger logger = LoggerFactory.getLogger(AsyncKekka.class);
+
+  @Autowired
+  private MatchMapper matchMapper;
+
+  @Async
+  public void waitResult(SseEmitter emitter, int userId) throws IOException {
+    logger.info("AsyncKekka.waitResult");
+    try {
+      Match match;
+
+      while (true) {
+        match = matchMapper.selectActiveMatchByUser(userId);
+        logger.info("Match Checking: " + (match != null));
+
+        if (match != null) {
+          String userHand = match.getUser1Hand();
+          String opponentHand = match.getUser2Hand();
+          if (match.getUser1() != userId) {
+            String tmp = userHand;
+            userHand = opponentHand;
+            opponentHand = tmp;
+          }
+
+          emitter.send(
+              String.format(
+                  """
+                        <h2>対戦結果</h2>
+                        <div>あなたの手 %s</div>
+                        <div>相手の手 %s</div>
+                        <div>結果 %s</div>
+
+                        <p><a href="/janken">もどる</a></p>
+                      """,
+                  userHand, opponentHand,
+                  Janken.outputResult(userHand, opponentHand)));
+
+          TimeUnit.MILLISECONDS.sleep(1000);
+          matchMapper.deactivateMatchById(match.getId());
+
+          break;
+        }
+
+        TimeUnit.MILLISECONDS.sleep(500);
+      }
+    } catch (InterruptedException e) {
+      e.printStackTrace();
+    }
+  }
+}

--- a/src/main/resources/templates/wait.html
+++ b/src/main/resources/templates/wait.html
@@ -10,6 +10,15 @@
   <meta name="keywords" content="" />
   <meta name="description" content="" />
 
+  <script type="text/javascript">
+    window.onload = function () {
+      const sse = new EventSource("/fight/waiting");
+      sse.onmessage = function (event) {
+        console.log("Received result!");
+        document.getElementById("result").innerHTML = event.data;
+      }
+    }
+  </script>
 </head>
 
 <body>
@@ -20,8 +29,10 @@
 
   <p>[[${userName}]] vs [[${opponentName}]]</p>
 
-  <h2>相手の手を待ってます</h2>
-  <div th:if="${userHand}">あなたの手 [[${userHand}]]</div>
+  <div id="result">
+    <h2>相手の手を待ってます</h2>
+    <div th:if="${userHand}">あなたの手 [[${userHand}]]</div>
+  </div>
 </body>
 
 </html>


### PR DESCRIPTION
[概要]
　第5回応用演習(授業課題) Web資料の個人演習「対戦相手が手を選び非同期処理で結果を表示する」の項を実装し完了した。

[動作確認]
　確認済み。

[DoD]
　「ほんだ」でログイン後、「いがき」を選択し、じゃんけんの手を選び、wait.htmlに遷移できることを確認する
>> 確認できた．

　別のブラウザやシークレットモードで「いがき」でログイン後、「ほんだ」を選択し、じゃんけんの手を選び、wait.htmlに遷移できることを確認する
>> 確認できた．

　「ほんだ」，「いがき」でログインしているブラウザで結果が 非同期に表示されることを確認する
>> 確認できた．

[実行/実装事項]
・(省略)